### PR TITLE
cause() works for errors from different contexts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test:
 	node tests/tst.verror.js
 	node tests/tst.werror.js
 	node tests/tst.serror.js
+	node tests/tst.context.js
 	@echo all tests passed
 
 include ./Makefile.targ

--- a/lib/verror.js
+++ b/lib/verror.js
@@ -6,6 +6,7 @@ var mod_assert = require('assert');
 var mod_util = require('util');
 
 var mod_extsprintf = require('extsprintf');
+var mod_isError = require('core-util-is').isError;
 
 /*
  * Public interface
@@ -50,7 +51,7 @@ function VError(options)
 		return (obj);
 	}
 
-	if (options instanceof Error || typeof (options) === 'object') {
+	if (mod_isError(options) || typeof (options) === 'object') {
 		args = Array.prototype.slice.call(arguments, 1);
 	} else {
 		args = Array.prototype.slice.call(arguments, 0);
@@ -96,10 +97,10 @@ function VError(options)
 	if (options) {
 		causedBy = options.cause;
 
-		if (!causedBy || !(options.cause instanceof Error))
+		if (!causedBy || !mod_isError(options.cause))
 			causedBy = options;
 
-		if (causedBy && (causedBy instanceof Error)) {
+		if (causedBy && mod_isError(causedBy)) {
 			this.jse_cause = causedBy;
 			this.jse_summary += ': ' + causedBy.message;
 		}
@@ -149,7 +150,7 @@ function SError()
 	opts = {};
 	opts.constructorOpt = SError;
 
-	if (arguments[0] instanceof Error) {
+	if (mod_isError(arguments[0])) {
 		opts.cause = arguments[0];
 		fmtargs = Array.prototype.slice.call(arguments, 1);
 	} else if (typeof (arguments[0]) == 'object') {
@@ -210,7 +211,7 @@ function WError(options)
 	}
 
 	if (options) {
-		if (options instanceof Error) {
+		if (mod_isError(options)) {
 			cause = options;
 		} else {
 			cause = options.cause;
@@ -242,7 +243,7 @@ WError.prototype.toString = function we_toString()
 
 WError.prototype.cause = function we_cause(c)
 {
-	if (c instanceof Error)
+	if (mod_isError(c))
 		this.we_cause = c;
 
 	return (this.we_cause);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"url": "git://github.com/davepacheco/node-verror.git"
 	},
 	"dependencies": {
+		"core-util-is": "^1.0.2",
 		"extsprintf": "1.2.0"
 	},
 	"engines": [

--- a/tests/tst.context.js
+++ b/tests/tst.context.js
@@ -15,10 +15,10 @@ var verr = new VError(err);
 mod_assert.ok(mod_isError(verr.cause()));
 
 var context = mod_vm.createContext({
-  callback: function callback(err) {
-    mod_assert.ok(mod_isError(err));
-    var verr = new VError(err);
-    mod_assert.ok(mod_isError(verr.cause()));
-  },
+	callback: function callback(err2) {
+		mod_assert.ok(mod_isError(err2));
+		var verr2 = new VError(err);
+		mod_assert.ok(mod_isError(verr2.cause()));
+	}
 });
 mod_vm.runInContext('callback(new Error())', context);

--- a/tests/tst.context.js
+++ b/tests/tst.context.js
@@ -1,0 +1,24 @@
+/*
+ * tst.context.js: tests that cause works with errors from different contexts.
+ */
+
+var mod_assert = require('assert');
+var mod_verror = require('../lib/verror');
+var mod_isError = require('core-util-is').isError;
+var mod_vm = require('vm');
+
+var VError = mod_verror.VError;
+var WError = mod_verror.WError;
+
+var err = new Error();
+var verr = new VError(err);
+mod_assert.ok(mod_isError(verr.cause()));
+
+var context = mod_vm.createContext({
+  callback: function callback(err) {
+    mod_assert.ok(mod_isError(err));
+    var verr = new VError(err);
+    mod_assert.ok(mod_isError(verr.cause()));
+  },
+});
+mod_vm.runInContext('callback(new Error())', context);


### PR DESCRIPTION
err instanceof Error does not work with errors from different contexts
because the prototype chain is different (e.g. Error in context 1 is
different from Error in context 2). The node core gets around this by
using isError, which checks for errors in the following way:

```
function isError(e) {
  return (objectToString(e) === '[object Error]' || e instanceof Error);
}
```

Which is backwards compatible with the current approach of only checking
`instanceof Error`.

 - Add tst.context.js to test that 'cause()' works for errors from
   different contexts.
 - Add 'core-util-is'.
 - Replace all instances of 'instanceof Error' with 'mod_isError(err)'.

I haven't run 'make check' because I couldn't figure out how to download the needed tools.